### PR TITLE
Fixed error where the ID in an Image record did not match the Image

### DIFF
--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -176,7 +176,7 @@ namespace miceExplorationTool.Pages
             foreach (string File in Filepaths)//iterates throught the image filepaths, and matches to the tags, and stores in an Image object
             {
                 List<string> files = new List<string>();
-                string id = GetID(Filepaths[0]);//gets the ID from the image
+                string id = GetID(File);//gets the ID from the image
                 files.Add(File);//adds the 
                 List<Tags> t = FindList(id, SortedTags);
                 Image Mouse = new Image(id);


### PR DESCRIPTION
Corrected issue where ID was being assigned as the first Image ID in a list passed to it.
Tested by having each Image class print out their ID, and the Tags lists Download tag.
